### PR TITLE
Added functionality to select theme.

### DIFF
--- a/code/forms/MarkdownEditor.php
+++ b/code/forms/MarkdownEditor.php
@@ -1,26 +1,80 @@
 <?php
 class MarkdownEditor extends TextareaField {
     protected $rows=30;
-    
+
+    /**
+     * Default site-wide theme for the ace editor.
+     * @var string - See {@link http://ace.ajax.org/#nav=howto}
+    **/
+    static protected $default_theme = "ace/theme/twilight";
+
+    /**
+     * MarkdownEditor instance theme
+     * @var string - See {@link http://ace.ajax.org/#nav=howto}
+    **/
+    protected $theme;
+
+    /**
+     * Set the default site-wide theme of the Ace editor.
+     * @param $theme string - path to the theme. See {@link http://ace.ajax.org/#nav=howto}
+    **/
+    public static function set_default_theme($theme)
+    {
+        self::$default_theme = (string) $theme;
+    }
+
+    /**
+     * Returns the ace editor default theme.
+     * @return string
+    **/
+    public static function get_default_theme()
+    {
+        return (string) self::$default_theme;
+    }
+
+    /**
+     * Set a theme for the current instance.
+     * @param $theme string
+    **/
+    public function setTheme($theme)
+    {
+        $this->theme = (string) $theme;
+    }
+
+    /**
+     * Return the current instance theme.
+     * @return string
+    **/
+    public function getTheme()
+    {
+        if(!$this->theme)
+            return self::get_default_theme();
+        return (string) $this->theme;
+    }
+
     /**
      * Returns the field holder used by templates
      * @return {string} HTML to be used
      */
     public function FieldHolder($properties=array()) {
         $this->extraClasses['stacked']='stacked';
-        
-        
-        
+
         Requirements::css(MARKDOWN_MODULE_BASE.'/css/MarkdownEditor.css');
-        
+
         Requirements::javascript(MARKDOWN_MODULE_BASE.'/javascript/external/ace/ace.js');
         Requirements::javascript(MARKDOWN_MODULE_BASE.'/javascript/external/ace/mode-markdown.js');
-        Requirements::javascript(MARKDOWN_MODULE_BASE.'/javascript/external/ace/theme-textmate.js');
+
+        // Fallback theme
         Requirements::javascript(MARKDOWN_MODULE_BASE.'/javascript/external/ace/theme-twilight.js');
-        Requirements::javascript(MARKDOWN_MODULE_BASE.'/javascript/MarkdownEditor.js');
+
+        $vars = array(
+            "Theme" => "'" . $this->getTheme() . "'"
+        );
+        Requirements::javascriptTemplate(MARKDOWN_MODULE_BASE.'/javascript/MarkdownEditor.js', $vars);
+
         return parent::FieldHolder($properties);
     }
-    
+
     /**
      * Generates the attributes to be used on the field
      * @return {array} Array of attributes to be used on the form field

--- a/javascript/MarkdownEditor.js
+++ b/javascript/MarkdownEditor.js
@@ -12,22 +12,22 @@
                                 width: '100%',
                                 height: $(this).height()
                             });
-                
+
                 $(this).setTextArea($(this));
                 $(this).hide();
-                
+
                 var div=$('<div id="'+$(this).attr('ID')+'_Editor" class="markdowneditor_editor"/>').css('height', $(this).getFrame().height).css('width', $(this).getFrame().width).text($(this).val());
                 div.insertAfter($(this));
                 $(this).setDiv(div);
-                
+
                 var editor=ace.edit(div.get(0));
                 editor.getSession().setMode('ace/mode/markdown');
                 editor.setShowPrintMargin(false);
-                editor.setTheme('ace/theme/twilight');
+                editor.setTheme($Theme);
                 editor.resize();
                 div.removeClass('ace_dark');
                 $(this).setEditor(editor);
-                
+
                 var code=$(this).val();
                 $(this).setUseSoftTabs($(this).usesSoftTabs(code));
                 $(this).setTabSize($(this).getSoftTabs() ? $(this).guessTabSize(code):8);


### PR DESCRIPTION
The change allows the dev to set a default site-wide theme using MarkdownEditor::set_default_theme as well as instance-based themes set by $markdownEditor->setTheme("ace/theme/textmate").

Might it be a good idea to add more themes to choose from?
