### PR TITLE
Implement alternative renderer and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Markdown Editor and DBField
 =================
 
-Adds a field and a data type that allows for Markdown editing, uses the github api to render the html
+Adds a field and a data type that allows for Markdown editing, uses a supported renderer (default is the github api) to render the html
 
 ## Requirements
 * SilverStripe 3.x
@@ -14,4 +14,58 @@ Adds a field and a data type that allows for Markdown editing, uses the github a
 * Upon entering the cms and using MarkdownEditor for the first time you make need to add ?flush=all to the end of the address to force the templates to regenerate
 
 ## Usage
-Use the Markdown data type as your fields data type, then use the MarkdownEditor field in the cms for editing. You may also request the markdown using Github Flavored Markdown by calling $YourField.AsHTML(true) in your template by default Github Flavored Markdown is not used just regular Markdown is used. Alternativly you can enable this site wide using Markdown::setUseGFM(true); in your _config.php
+Use the Markdown data type as your fields data type, then use the MarkdownEditor field in the cms for editing.
+
+###Page class:
+	class MyPage extends Page {
+		
+		public static $db = array(
+			"MarkdownContent" => "Markdown"
+		);
+
+		public function getCMSFields() {
+			$fields = parent::getCMSFields();
+			$fields->addFieldToTab("Root.Main", new MarkdownEditor("MarkdownContent", "Page Content (Markdown)"));
+			return $fields;
+		}
+
+	}
+
+
+###Template:
+	
+	<div class="content">
+		$MarkdownContent  <!-- Will show as rendered html -->
+	</div>
+
+You may also request the markdown using Github Flavored Markdown by calling $YourField.AsHTML(true) in your template by default Github Flavored Markdown is not used just regular Markdown is used.
+
+	<div class="content">
+		$MarkdownContent.AsHTML(true)  <!-- Will render the content using Github Flavoured Markdown -->
+	</div>
+
+###Configuration:
+The default renderer is the Github renderer. However, other renderers are supported. Also, the Github renderer has some configurable options.
+
+To set the renderer to use, in **_config.php** do the following:
+
+	$renderer = new GithubMarkdownRenderer(); //any implementation of IMarkdownRenderer will work
+	Markdown::setRenderer($renderer);
+
+####GithubMarkdownRenderer
+The following options are available on the default GithubMarkdownRenderer:
+
+	$renderer = new GithubMarkdownRenderer();
+	$renderer->useBasicAuth(); //authenticate to the Github API to get 5,000 requests per hour instead of 60
+	$renderer->setGithubUsername("github username"); //auth username
+	$renderer->setGithubPassword("github password"); //auth password
+	$renderer->setUseGFM(true); //whether or not to use Github Flavoured Markdown
+	Markdown::setRenderer($renderer);
+
+####PHPMarkdownMarkdownRenderer
+PHPMarkdownMarkdownRenderer is simple and has no options. Use this to avoid the delay on page load that comes from using the Github renderer (especially if the page has many sections of markdown). You will need to install [PHP Markdown](https://github.com/michelf/php-markdown) for this to work.
+
+**Note:** This renderer does not support Github Flavoured Markdown.
+
+	$renderer = new PHPMarkdownMarkdownRenderer();
+	Markdown::setRenderer($renderer);

--- a/code/renderer/GithubMarkdownRenderer.php
+++ b/code/renderer/GithubMarkdownRenderer.php
@@ -1,0 +1,102 @@
+<?php
+
+class GithubMarkdownRenderer implements IMarkdownRenderer {
+
+	protected $useGFM = false;
+	protected $useBasicAuth = false;
+	protected $username = "";
+	protected $password = "";
+
+	public function __construct($useGFM = false) {
+		$this->useGFM = $useGFM;
+	}
+
+	public function isSupported() {
+		$supported = function_exists("curl_version");
+		if (!$supported) {
+			$supported = "CURL not found.";
+		}
+		return $supported;
+	}
+
+	public function getRenderedHTML($value) {
+   		//Build object to send
+        $sendObj=new stdClass();
+        $sendObj->text=$value;
+        $sendObj->mode=($this->useGFM ? 'gmf':'markdown');
+        $content=json_encode($sendObj);
+
+        //Build headers
+        $headers = array("Content-type: application/json", "User-Agent: curl");
+        if ($this->useBasicAuth) {
+            $username = $this->username;
+            $password = $this->password;
+            $encoded = base64_encode("$username:$password");
+            $headers[] = "Authorization: Basic $encoded";
+        }        
+        
+        //Build curl request to github's api
+        $curl=curl_init('https://api.github.com/markdown');
+        curl_setopt($curl, CURLOPT_HEADER, false);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+        curl_setopt($curl, CURLOPT_POST, true);
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $content);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+        
+        
+        //Send request and verify response
+        $response=curl_exec($curl);
+        $status=curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        if($status!=200) {
+            user_error("Error: Call to api.github.com failed with status $status, response $response, curl_error ".curl_error($curl).", curl_errno ".curl_errno($curl), E_USER_WARNING);
+        }
+        
+        //Close curl connection
+        curl_close($curl);
+
+        return $response;
+	}
+
+    /**
+     * Globally enable or disable github flavored markdown
+     * @param {bool} $val Boolean true to enable false otherwise
+     * @default true
+     */
+    public function setUseGFM($value) {
+        $this->useGFM=$value;
+    }
+    
+    /**
+     * Gets if github flavored markdown is enabled or not globally
+     * @return {bool} Returns boolean true if github flavored markdown is enabled false otherwise
+     */
+    public function getUseGFM() {
+        return $this->useGFM;
+    }
+
+    /**
+     * Sets whether or not to include the Authorization header in GitHub API requests
+     * @param {bool} $use Boolean true to enable false otherwise
+     */
+    public function useBasicAuth($use = true) {
+        $this->useBasicAuth = $use;
+    }
+
+    /**
+     * Sets the GitHub username for Basic Auth
+     * @param {string} $username Your GitHub username
+     */
+    public function setGithubUsername($username) {
+        $this->username = $username;
+    }
+
+    /**
+     * Sets the GitHub password for Basic Auth
+     * @param {string} $password Your GitHub password
+     */
+    public function setGithubPassword($password) {
+        $this->password = $password;
+    }	
+	
+}

--- a/code/renderer/IMarkdownRenderer.php
+++ b/code/renderer/IMarkdownRenderer.php
@@ -1,0 +1,21 @@
+<?php
+
+interface IMarkdownRenderer {
+
+	/**
+	 * Performs the necessary checks to determine if the markdown renderer is
+	 * supported on the system (eg, check necessary libraries are available etc)
+	 * 
+	 * @return {mixed} {bool} True if the renderer is supported, or {string}
+	 * error message detailing why the renderer isnt supported
+	 */
+	public function isSupported();
+
+	/**
+	 * Returns the supplied Markdown as rendered HTML
+	 * @param {string} $markdown The markdown to render
+	 * @return {string} The rendered HTML
+	 */
+	public function getRenderedHTML($markdown);
+
+}

--- a/code/renderer/PHPMarkdownMarkdownRenderer.php
+++ b/code/renderer/PHPMarkdownMarkdownRenderer.php
@@ -1,0 +1,17 @@
+<?php
+
+class PHPMarkdownMarkdownRenderer implements IMarkdownRenderer {
+
+	public function isSupported() {
+		$exists = class_exists("\Michelf\Markdown");
+		if (!$exists) {
+			return "Unable to find the php-markdown class (\Michelf\Markdown) on the classpath.";
+		}
+		return $exists;
+	}
+
+	public function getRenderedHTML($markdown) {
+		return \Michelf\Markdown::defaultTransform($markdown);
+	}
+
+}


### PR DESCRIPTION
Decouple rendering from the Markdown field class and into an interface, then implement the interface for GitHub to restore the old functionality. Also add an alternative implementation for [PHP Markdown](https://github.com/michelf/php-markdown) and update the README.md file to describe the configuration.
