### PR TITLE
PHPMarkdownMarkdownRenderer readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,9 @@ GithubMarkdownRenderer::setUseGFM(true); //whether or not to use Github Flavoure
 ```
 
 ####PHPMarkdownMarkdownRenderer
-PHPMarkdownMarkdownRenderer is simple and has no options. Use this to avoid the delay on page load the first time after editing that comes from using the Github renderer (especially if the page has many sections of markdown). You will need to install [PHP Markdown](https://github.com/michelf/php-markdown) for this to work.
+PHPMarkdownMarkdownRenderer is simple and has no options. Use this to avoid the delay on page load the first time after editing that comes from using the Github renderer (especially if the page has many sections of markdown). You will need to install [PHP Markdown](https://github.com/michelf/php-markdown) for this to work - it can be installed with composer.
 
 **Note:** This renderer does not support Github Flavoured Markdown.
 ```php
-$renderer=new PHPMarkdownMarkdownRenderer();
-Markdown::setRenderer($renderer);
+Markdown::setRenderer('PHPMarkdownMarkdownRenderer');
 ```


### PR DESCRIPTION
* Adjusted readme: use the markdown renderer name as a string rather than class instance.

`Markdown::setRenderer(new PHPMarkdownMarkdownRender)` will trigger error:

>Catchable fatal error: Object of class PHPMarkdownMarkdownRenderer could not be converted to string in /var/www/markdown/code/model/fieldtypes/Markdown.php on line 94

Use string literal class name as suggested for the `GithubMarkdownRenderer` (`PHPMarkdownMarkdownRenderer`) works.